### PR TITLE
Ensure beforeInit hooks run only in module steps

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,10 @@ export class Custard {
 
   beforeModulesInit() {
     this.modules.forEach(module => {
-      if (typeof module.beforeInit === 'function') {
-        module.beforeInit();
+      if (module.steps().includes(this.step)) {
+        if (typeof module.beforeInit === 'function') {
+          module.beforeInit();
+        }
       }
     });
   }


### PR DESCRIPTION
## Overview
The `beforeInit` hooks do not currently consider module steps at all, and as a result all `beforeInit` hooks are run in each step. This PR fixes this by adding a module steps check identical to the one performed before `init`.