### PR TITLE
CH11862: Refine custard submarine-js interplay

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "root": true,
   "extends": [
+    "airbnb-base",
     "plugin:prettier/recommended",
     "plugin:import/errors",
     "plugin:import/warnings"

--- a/.eslintrc
+++ b/.eslintrc
@@ -55,6 +55,7 @@
           "_destroy"
         ]
       }
-    ]
+    ],
+    "class-methods-use-this": "off"
   }
 }

--- a/index.js
+++ b/index.js
@@ -24,15 +24,8 @@ export class Custard {
     this.options = options;
 
     this.attachAdditionalContext();
-
-    // Call beforeInit hook for each of modules
-    this.beforeModulesInit();
-
-    // Register event listeners.
-    this.$(document).on(
-      'page:load page:change',
-      this.pageChangeHandler.bind(this)
-    );
+    this.callBeforeInit();
+    this.registerEventListeners();
   }
 
   attachAdditionalContext() {
@@ -55,7 +48,7 @@ export class Custard {
       .filter(module => module === null);
   }
 
-  beforeModulesInit() {
+  callBeforeInit() {
     this.modules.forEach(module => {
       if (module.steps().includes(this.step)) {
         if (typeof module.beforeInit === 'function') {
@@ -65,7 +58,14 @@ export class Custard {
     });
   }
 
-  pageChangeHandler() {
+  registerEventListeners() {
+    this.$(document).on(
+      'page:load page:change',
+      this.pageChangeHandler.bind(this)
+    );
+  }
+
+  pageChangeHandler(event) {
     this.modules.forEach(module => {
       if (module.steps().includes(this.step)) {
         if (

--- a/index.js
+++ b/index.js
@@ -4,10 +4,16 @@ export const STEP_PAYMENT_METHOD = 'payment_method';
 export const STEP_REVIEW = 'review';
 export const STEP_THANK_YOU = 'thank_you';
 export const STEP_ORDER_STATUS = 'order_status';
-export const STEPS_ALL = [STEP_CONTACT_INFORMATION, STEP_SHIPPING_METHOD, STEP_PAYMENT_METHOD, STEP_REVIEW, STEP_THANK_YOU, STEP_ORDER_STATUS];
+export const STEPS_ALL = [
+  STEP_CONTACT_INFORMATION,
+  STEP_SHIPPING_METHOD,
+  STEP_PAYMENT_METHOD,
+  STEP_REVIEW,
+  STEP_THANK_YOU,
+  STEP_ORDER_STATUS
+];
 
 export class Custard {
-
   constructor(moduleClasses) {
     this.moduleClasses = moduleClasses;
   }
@@ -18,7 +24,7 @@ export class Custard {
     this.options = options;
 
     // Instantiate module classes.
-    this.modules = this.moduleClasses.map((moduleClass) => {
+    this.modules = this.moduleClasses.map(moduleClass => {
       return new moduleClass($, step, options);
     });
 
@@ -26,7 +32,10 @@ export class Custard {
     this.beforeModulesInit();
 
     // Register event listeners.
-    this.$(document).on('page:load page:change', this.pageChangeHandler.bind(this));
+    this.$(document).on(
+      'page:load page:change',
+      this.pageChangeHandler.bind(this)
+    );
   }
 
   beforeModulesInit() {
@@ -40,9 +49,12 @@ export class Custard {
   }
 
   pageChangeHandler(event) {
-    this.modules.forEach((module) => {
-      if(module.steps().includes(this.step)) {
-        if(this.step === STEP_SHIPPING_METHOD && this.isPollRefreshElementPresent()) {
+    this.modules.forEach(module => {
+      if (module.steps().includes(this.step)) {
+        if (
+          this.step === STEP_SHIPPING_METHOD &&
+          this.isPollRefreshElementPresent()
+        ) {
           return;
         }
 
@@ -54,11 +66,9 @@ export class Custard {
   isPollRefreshElementPresent() {
     return this.$('[data-poll-refresh]').length;
   }
-
 }
 
 export class CustardModule {
-
   constructor($, step, options) {
     this.$ = $;
     this.step = step;
@@ -85,7 +95,7 @@ export class CustardModule {
     this.$element = this.$(this.selector());
 
     // Bail if already initialised.
-    if(this.$element.hasClass(this.id())) {
+    if (this.$element.hasClass(this.id())) {
       return;
     }
 
@@ -95,5 +105,4 @@ export class CustardModule {
   }
 
   setup() {}
-
 }

--- a/index.js
+++ b/index.js
@@ -1,125 +1,23 @@
-export const STEP_CONTACT_INFORMATION = 'contact_information';
-export const STEP_SHIPPING_METHOD = 'shipping_method';
-export const STEP_PAYMENT_METHOD = 'payment_method';
-export const STEP_REVIEW = 'review';
-export const STEP_THANK_YOU = 'thank_you';
-export const STEP_ORDER_STATUS = 'order_status';
-export const STEPS_ALL = [
+import CustardModule from './src/custard_module';
+import Custard from './src/custard';
+import {
   STEP_CONTACT_INFORMATION,
   STEP_SHIPPING_METHOD,
   STEP_PAYMENT_METHOD,
   STEP_REVIEW,
   STEP_THANK_YOU,
-  STEP_ORDER_STATUS
-];
+  STEP_ORDER_STATUS,
+  STEPS_ALL
+} from './src/constants';
 
-export class Custard {
-  constructor(modules) {
-    this.modules = modules;
-  }
-
-  init($, step, options = {}) {
-    this.$ = $;
-    this.step = step;
-    this.options = options;
-
-    this.attachAdditionalContext();
-    this.callBeforeInit();
-    this.registerEventListeners();
-  }
-
-  attachAdditionalContext() {
-    this.modules = this.modules
-      .map(module => {
-        if (module instanceof CustardModule) {
-          module.$ = this.$;
-          module.step = this.step;
-          module.options = Object.assign(this.options, module.options);
-          return module;
-        }
-
-        if (typeof module === 'function') {
-          const Module = module;
-          return new Module(this.$, this.step, this.options);
-        }
-
-        return null;
-      })
-      .filter(module => module === null);
-  }
-
-  callBeforeInit() {
-    this.modules.forEach(module => {
-      if (module.steps().includes(this.step)) {
-        if (typeof module.beforeInit === 'function') {
-          module.beforeInit();
-        }
-      }
-    });
-  }
-
-  registerEventListeners() {
-    this.$(document).on(
-      'page:load page:change',
-      this.pageChangeHandler.bind(this)
-    );
-  }
-
-  pageChangeHandler(event) {
-    this.modules.forEach(module => {
-      if (module.steps().includes(this.step)) {
-        if (
-          this.step === STEP_SHIPPING_METHOD &&
-          this.isPollRefreshElementPresent()
-        ) {
-          return;
-        }
-
-        module.init();
-      }
-    });
-  }
-
-  isPollRefreshElementPresent() {
-    return this.$('[data-poll-refresh]').length;
-  }
-}
-
-export class CustardModule {
-  constructor($, step, options) {
-    this.$ = $;
-    this.step = step;
-    this.options = options;
-
-    this.$element = null;
-  }
-
-  id() {
-    throw 'Not implemented';
-  }
-
-  steps() {
-    return [];
-  }
-
-  selector() {
-    return 'document';
-  }
-
-  beforeInit() {}
-
-  init() {
-    this.$element = this.$(this.selector());
-
-    // Bail if already initialised.
-    if (this.$element.hasClass(this.id())) {
-      return;
-    }
-
-    // Setup
-    this.$element.addClass(this.id());
-    this.setup();
-  }
-
-  setup() {}
-}
+export {
+  Custard,
+  CustardModule,
+  STEP_CONTACT_INFORMATION,
+  STEP_SHIPPING_METHOD,
+  STEP_PAYMENT_METHOD,
+  STEP_REVIEW,
+  STEP_THANK_YOU,
+  STEP_ORDER_STATUS,
+  STEPS_ALL
+};

--- a/index.test.js
+++ b/index.test.js
@@ -1,4 +1,4 @@
-import { CustardModule, STEPS_ALL } from './index';
+import { STEPS_ALL } from './index';
 
 test('expected steps in STEPS_ALL', () => {
   expect(STEPS_ALL.length).toBeGreaterThanOrEqual(6);

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   "scripts": {
     "test": "./node_modules/jest/bin/jest.js",
     "lint": "./node_modules/eslint/bin/eslint.js -c .eslintrc --ext js ."
+  },
+  "dependencies": {
+    "lodash": "^4.17.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/register": "^7.5.5",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.2.2",
+    "eslint-config-airbnb-base": "^14.1.0",
     "eslint-config-prettier": "^6.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,14 @@
+export const STEP_CONTACT_INFORMATION = 'contact_information';
+export const STEP_SHIPPING_METHOD = 'shipping_method';
+export const STEP_PAYMENT_METHOD = 'payment_method';
+export const STEP_REVIEW = 'review';
+export const STEP_THANK_YOU = 'thank_you';
+export const STEP_ORDER_STATUS = 'order_status';
+export const STEPS_ALL = [
+  STEP_CONTACT_INFORMATION,
+  STEP_SHIPPING_METHOD,
+  STEP_PAYMENT_METHOD,
+  STEP_REVIEW,
+  STEP_THANK_YOU,
+  STEP_ORDER_STATUS
+];

--- a/src/custard.js
+++ b/src/custard.js
@@ -1,0 +1,74 @@
+import { STEP_SHIPPING_METHOD } from './constants';
+import CustardModule from './custard_module';
+
+export default class Custard {
+  constructor(modules) {
+    this.modules = modules;
+  }
+
+  init($, step, options = {}) {
+    this.$ = $;
+    this.step = step;
+    this.options = options;
+
+    this.attachAdditionalContext();
+    this.callBeforeInit();
+    this.registerEventListeners();
+  }
+
+  attachAdditionalContext() {
+    this.modules = this.modules
+      .map(module => {
+        if (module instanceof CustardModule) {
+          module.$ = this.$;
+          module.step = this.step;
+          module.options = Object.assign(this.options, module.options);
+          return module;
+        }
+
+        if (typeof module === 'function') {
+          const Module = module;
+          return new Module(this.$, this.step, this.options);
+        }
+
+        return null;
+      })
+      .filter(module => module === null);
+  }
+
+  callBeforeInit() {
+    this.modules.forEach(module => {
+      if (module.steps().includes(this.step)) {
+        if (typeof module.beforeInit === 'function') {
+          module.beforeInit();
+        }
+      }
+    });
+  }
+
+  registerEventListeners() {
+    this.$(document).on(
+      'page:load page:change',
+      this.pageChangeHandler.bind(this)
+    );
+  }
+
+  pageChangeHandler() {
+    this.modules.forEach(module => {
+      if (module.steps().includes(this.step)) {
+        if (
+          this.step === STEP_SHIPPING_METHOD &&
+          this.isPollRefreshElementPresent()
+        ) {
+          return;
+        }
+
+        module.init();
+      }
+    });
+  }
+
+  isPollRefreshElementPresent() {
+    return this.$('[data-poll-refresh]').length;
+  }
+}

--- a/src/custard.js
+++ b/src/custard.js
@@ -19,21 +19,17 @@ export default class Custard {
   attachAdditionalContext() {
     this.modules = this.modules
       .map(module => {
-        if (module instanceof CustardModule) {
-          module.$ = this.$;
-          module.step = this.step;
-          module.options = Object.assign(this.options, module.options);
-          return module;
-        }
-
-        if (typeof module === 'function') {
+        if (module.__proto__.name === 'CustardModule') {
           const Module = module;
-          return new Module(this.$, this.step, this.options);
+          module = new Module(this.options);
         }
 
-        return null;
+        module.$ = this.$;
+        module.step = this.step;
+        module.options = Object.assign(this.options, module.options);
+        return module;
       })
-      .filter(module => module === null);
+      .filter(module => module !== null);
   }
 
   callBeforeInit() {

--- a/src/custard.js
+++ b/src/custard.js
@@ -11,12 +11,12 @@ export default class Custard {
     this.step = step;
     this.options = options;
 
-    this.attachAdditionalContext();
+    this.initializeModules();
     this.callBeforeInit();
     this.registerEventListeners();
   }
 
-  attachAdditionalContext() {
+  initializeModules() {
     this.modules = this.modules
       .map(module => {
         if (module.__proto__.name === 'CustardModule') {

--- a/src/custard_module.js
+++ b/src/custard_module.js
@@ -8,7 +8,7 @@ export default class CustardModule {
   }
 
   id() {
-    throw 'Not implemented';
+    throw new Error('Not implemented');
   }
 
   steps() {

--- a/src/custard_module.js
+++ b/src/custard_module.js
@@ -1,0 +1,38 @@
+export default class CustardModule {
+  constructor($, step, options) {
+    this.$ = $;
+    this.step = step;
+    this.options = options;
+
+    this.$element = null;
+  }
+
+  id() {
+    throw 'Not implemented';
+  }
+
+  steps() {
+    return [];
+  }
+
+  selector() {
+    return 'document';
+  }
+
+  beforeInit() {}
+
+  init() {
+    this.$element = this.$(this.selector());
+
+    // Bail if already initialised.
+    if (this.$element.hasClass(this.id())) {
+      return;
+    }
+
+    // Setup
+    this.$element.addClass(this.id());
+    this.setup();
+  }
+
+  setup() {}
+}

--- a/src/custard_module.js
+++ b/src/custard_module.js
@@ -1,7 +1,5 @@
 export default class CustardModule {
-  constructor($, step, options) {
-    this.$ = $;
-    this.step = step;
+  constructor(options) {
     this.options = options;
 
     this.$element = null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,7 +2789,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,6 +1214,11 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
+confusing-browser-globals@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz#72bc13b483c0276801681871d4898516f8f54fdd"
+  integrity sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==
+
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -1421,9 +1426,35 @@ es-abstract@^1.12.0, es-abstract@^1.5.1, es-abstract@^1.7.0:
     is-regex "^1.0.4"
     object-keys "^1.0.12"
 
+es-abstract@^1.17.0-next.1:
+  version "1.17.4"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
+  integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.1.5"
+    is-regex "^1.0.5"
+    object-inspect "^1.7.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimleft "^2.1.1"
+    string.prototype.trimright "^2.1.1"
+
 es-to-primitive@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
   dependencies:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
@@ -1443,6 +1474,15 @@ escodegen@^1.9.1:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+eslint-config-airbnb-base@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.1.0.tgz#2ba4592dd6843258221d9bff2b6831bd77c874e4"
+  integrity sha512-+XCcfGyCnbzOnktDVhwsCAx+9DmrzEmuwxyHUJpw+kqBVT744OUBrB09khgFKlK1lshVww6qXGsYPZpavoNjJw==
+  dependencies:
+    confusing-browser-globals "^1.0.9"
+    object.assign "^4.1.0"
+    object.entries "^1.1.1"
 
 eslint-config-prettier@^6.1.0:
   version "6.1.0"
@@ -1901,6 +1941,11 @@ has-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
 
+has-symbols@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
+  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -2053,6 +2098,11 @@ is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
 
+is-callable@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
+  integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
+
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
@@ -2146,6 +2196,13 @@ is-regex@^1.0.4:
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
     has "^1.0.1"
+
+is-regex@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
+  integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
+  dependencies:
+    has "^1.0.3"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -3008,7 +3065,12 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.11, object-keys@^1.0.12:
+object-inspect@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
+  integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
+
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
 
@@ -3026,6 +3088,16 @@ object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
+
+object.entries@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.1.tgz#ee1cf04153de02bb093fec33683900f57ce5399b"
+  integrity sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
@@ -3782,6 +3854,22 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string.prototype.trimleft@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz#9bdb8ac6abd6d602b17a4ed321870d2f8dcefc74"
+  integrity sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==
+  dependencies:
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
+
+string.prototype.trimright@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz#440314b15996c866ce8a0341894d45186200c5d9"
+  integrity sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==
+  dependencies:
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
 
 string_decoder@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Clubhouse: [ch12613](https://app.clubhouse.io/disco/story/12613/client-uat-feedback)

### Description
- Added `airbnb-base` eslint config which we also use in other projects to catch when variables are used that were not previously assigned and a number of other useful things.
- Allowed passing of already instantiated `CustardModule`s to the `Custard` constructor with module options, e.g.:
```
import { Custard } from "@discolabs/custard-js";
import { SubmarinePaymentMethodsModule } from "@discolabs/submarine-js";
import { StoredPaymentMethodPaymentMethod, StripeCreditCardPaymentMethod } from "@discolabs/submarine-js";
import CustardModuleA from "./custard_module_a";
import CustardModuleB from "./custard_module_b";
window.custard = new Custard([
  new CustardModuleA(),
  new CustardModuleB({
    moduleOption: 'value'
  })
]);
```
- By checking whether a module is a class or instance of a class, the change is backwards compatible so passing un-instantiated `CustardModule`s to `Custard` will still work. So if an existing project upgrades to the newest version of `submarine-js`, the usual way of calling `Custard` will not break:
```
window.custard = new Custard([
  HiddenAttributes,
  SubmarinePaymentMethodStep
]);
```
- Split `Custard`, `CustardModule` and constants into separate files.

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.