### PR TITLE
Refine class module check

### DIFF
--- a/src/custard.js
+++ b/src/custard.js
@@ -18,7 +18,10 @@ export default class Custard {
   initializeModules() {
     this.modules = this.modules
       .map(module => {
-        if (Object.getPrototypeOf(module).name === 'CustardModule') {
+        if (
+          typeof module === 'function' &&
+          /Cannot call a class/.test(Function.prototype.toString.call(module))
+        ) {
           const Module = module;
           module = new Module(this.options);
         }


### PR DESCRIPTION
### Description
- In Lyprinol, there are issues initializing modules for the minified production bundle. It turns out that we cannot rely on checking if the prototype name is `CustardModule` when the bundle has been minified. This PR checks if a module is a class by check if the following is true: 
```
typeof module === 'function' && /Cannot call a class/.test(Function.prototype.toString.call(module)
``` 