### PR TITLE
Refine class check

### DIFF
--- a/src/custard.js
+++ b/src/custard.js
@@ -18,10 +18,7 @@ export default class Custard {
   initializeModules() {
     this.modules = this.modules
       .map(module => {
-        if (
-          typeof module === 'function' &&
-          /Cannot call a class/.test(Function.prototype.toString.call(module))
-        ) {
+        if (typeof module.id === 'undefined') {
           const Module = module;
           module = new Module(this.options);
         }


### PR DESCRIPTION
### Description

- We previously checked if a module was a class by:
```
if (typeof module === 'function' && /Cannot call a class/.test(Function.prototype.toString.call(module)))
```
However, this is brittle and unreliable as babel, uglify, etc. convert everything into a plain JS function. 

Instead, as all instantiated `CustardModule`s will have the id() method, we could just check whether the `id()` method is defined. If not, then it's a class.